### PR TITLE
Implement AI players

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,596 @@
+GNU GENERAL PUBLIC LICENSE
+==========================
+
+Version 3, 29 June 2007
+
+Copyright &copy; 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+## Preamble
+
+The GNU General Public License is a free, copyleft license for software and other
+kinds of works.
+
+The licenses for most software and other practical works are designed to take away
+your freedom to share and change the works. By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change all versions of a
+program--to make sure it remains free software for all its users. We, the Free
+Software Foundation, use the GNU General Public License for most of our software; it
+applies also to any other work released this way by its authors. You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General
+Public Licenses are designed to make sure that you have the freedom to distribute
+copies of free software (and charge for them if you wish), that you receive source
+code or can get it if you want it, that you can change the software or use pieces of
+it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or
+asking you to surrender the rights. Therefore, you have certain responsibilities if
+you distribute copies of the software, or if you modify it: responsibilities to
+respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee,
+you must pass on to the recipients the same freedoms that you received. You must make
+sure that they, too, receive or can get the source code. And you must show them these
+terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert
+copyright on the software, and (2) offer you this License giving you legal permission
+to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is
+no warranty for this free software. For both users' and authors' sake, the GPL
+requires that modified versions be marked as changed, so that their problems will not
+be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of
+the software inside them, although the manufacturer can do so. This is fundamentally
+incompatible with the aim of protecting users' freedom to change the software. The
+systematic pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable. Therefore, we have designed
+this version of the GPL to prohibit the practice for those products. If such problems
+arise substantially in other domains, we stand ready to extend this provision to
+those domains in future versions of the GPL, as needed to protect the freedom of
+users.
+
+Finally, every program is threatened constantly by software patents. States should
+not allow patents to restrict development and use of software on general-purpose
+computers, but in those that do, we wish to avoid the special danger that patents
+applied to a free program could make it effectively proprietary. To prevent this, the
+GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+## TERMS AND CONDITIONS
+
+### 0. Definitions.
+
+&ldquo;This License&rdquo; refers to version 3 of the GNU General Public License.
+
+&ldquo;Copyright&rdquo; also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+&ldquo;The Program&rdquo; refers to any copyrightable work licensed under this
+License. Each licensee is addressed as &ldquo;you&rdquo;. &ldquo;Licensees&rdquo; and
+&ldquo;recipients&rdquo; may be individuals or organizations.
+
+To &ldquo;modify&rdquo; a work means to copy from or adapt all or part of the work in
+a fashion requiring copyright permission, other than the making of an exact copy. The
+resulting work is called a &ldquo;modified version&rdquo; of the earlier work or a
+work &ldquo;based on&rdquo; the earlier work.
+
+A &ldquo;covered work&rdquo; means either the unmodified Program or a work based on
+the Program.
+
+To &ldquo;propagate&rdquo; a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for infringement under
+applicable copyright law, except executing it on a computer or modifying a private
+copy. Propagation includes copying, distribution (with or without modification),
+making available to the public, and in some countries other activities as well.
+
+To &ldquo;convey&rdquo; a work means any kind of propagation that enables other
+parties to make or receive copies. Mere interaction with a user through a computer
+network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays &ldquo;Appropriate Legal Notices&rdquo; to the
+extent that it includes a convenient and prominently visible feature that (1)
+displays an appropriate copyright notice, and (2) tells the user that there is no
+warranty for the work (except to the extent that warranties are provided), that
+licensees may convey the work under this License, and how to view a copy of this
+License. If the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+### 1. Source Code.
+
+The &ldquo;source code&rdquo; for a work means the preferred form of the work for
+making modifications to it. &ldquo;Object code&rdquo; means any non-source form of a
+work.
+
+A &ldquo;Standard Interface&rdquo; means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of interfaces
+specified for a particular programming language, one that is widely used among
+developers working in that language.
+
+The &ldquo;System Libraries&rdquo; of an executable work include anything, other than
+the work as a whole, that (a) is included in the normal form of packaging a Major
+Component, but which is not part of that Major Component, and (b) serves only to
+enable use of the work with that Major Component, or to implement a Standard
+Interface for which an implementation is available to the public in source code form.
+A &ldquo;Major Component&rdquo;, in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system (if any) on which
+the executable work runs, or a compiler used to produce the work, or an object code
+interpreter used to run it.
+
+The &ldquo;Corresponding Source&rdquo; for a work in object code form means all the
+source code needed to generate, install, and (for an executable work) run the object
+code and to modify the work, including scripts to control those activities. However,
+it does not include the work's System Libraries, or general-purpose tools or
+generally available free programs which are used unmodified in performing those
+activities but which are not part of the work. For example, Corresponding Source
+includes interface definition files associated with source files for the work, and
+the source code for shared libraries and dynamically linked subprograms that the work
+is specifically designed to require, such as by intimate data communication or
+control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate
+automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+### 2. Basic Permissions.
+
+All rights granted under this License are granted for the term of copyright on the
+Program, and are irrevocable provided the stated conditions are met. This License
+explicitly affirms your unlimited permission to run the unmodified Program. The
+output from running a covered work is covered by this License only if the output,
+given its content, constitutes a covered work. This License acknowledges your rights
+of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without
+conditions so long as your license otherwise remains in force. You may convey covered
+works to others for the sole purpose of having them make modifications exclusively
+for you, or provide you with facilities for running those works, provided that you
+comply with the terms of this License in conveying all material for which you do not
+control copyright. Those thus making or running the covered works for you must do so
+exclusively on your behalf, under your direction and control, on terms that prohibit
+them from making any copies of your copyrighted material outside their relationship
+with you.
+
+Conveying under any other circumstances is permitted solely under the conditions
+stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+### 3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological measure under any
+applicable law fulfilling obligations under article 11 of the WIPO copyright treaty
+adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention
+of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of
+technological measures to the extent such circumvention is effected by exercising
+rights under this License with respect to the covered work, and you disclaim any
+intention to limit operation or modification of the work as a means of enforcing,
+against the work's users, your or third parties' legal rights to forbid circumvention
+of technological measures.
+
+### 4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you receive it, in any
+medium, provided that you conspicuously and appropriately publish on each copy an
+appropriate copyright notice; keep intact all notices stating that this License and
+any non-permissive terms added in accord with section 7 apply to the code; keep
+intact all notices of the absence of any warranty; and give all recipients a copy of
+this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer
+support or warranty protection for a fee.
+
+### 5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to produce it from
+the Program, in the form of source code under the terms of section 4, provided that
+you also meet all of these conditions:
+
+* **a)** The work must carry prominent notices stating that you modified it, and giving a
+relevant date.
+* **b)** The work must carry prominent notices stating that it is released under this
+License and any conditions added under section 7. This requirement modifies the
+requirement in section 4 to &ldquo;keep intact all notices&rdquo;.
+* **c)** You must license the entire work, as a whole, under this License to anyone who
+comes into possession of a copy. This License will therefore apply, along with any
+applicable section 7 additional terms, to the whole of the work, and all its parts,
+regardless of how they are packaged. This License gives no permission to license the
+work in any other way, but it does not invalidate such permission if you have
+separately received it.
+* **d)** If the work has interactive user interfaces, each must display Appropriate Legal
+Notices; however, if the Program has interactive interfaces that do not display
+Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are
+not by their nature extensions of the covered work, and which are not combined with
+it such as to form a larger program, in or on a volume of a storage or distribution
+medium, is called an &ldquo;aggregate&rdquo; if the compilation and its resulting
+copyright are not used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit. Inclusion of a covered work in an aggregate
+does not cause this License to apply to the other parts of the aggregate.
+
+### 6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms of sections 4 and
+5, provided that you also convey the machine-readable Corresponding Source under the
+terms of this License, in one of these ways:
+
+* **a)** Convey the object code in, or embodied in, a physical product (including a
+physical distribution medium), accompanied by the Corresponding Source fixed on a
+durable physical medium customarily used for software interchange.
+* **b)** Convey the object code in, or embodied in, a physical product (including a
+physical distribution medium), accompanied by a written offer, valid for at least
+three years and valid for as long as you offer spare parts or customer support for
+that product model, to give anyone who possesses the object code either (1) a copy of
+the Corresponding Source for all the software in the product that is covered by this
+License, on a durable physical medium customarily used for software interchange, for
+a price no more than your reasonable cost of physically performing this conveying of
+source, or (2) access to copy the Corresponding Source from a network server at no
+charge.
+* **c)** Convey individual copies of the object code with a copy of the written offer to
+provide the Corresponding Source. This alternative is allowed only occasionally and
+noncommercially, and only if you received the object code with such an offer, in
+accord with subsection 6b.
+* **d)** Convey the object code by offering access from a designated place (gratis or for
+a charge), and offer equivalent access to the Corresponding Source in the same way
+through the same place at no further charge. You need not require recipients to copy
+the Corresponding Source along with the object code. If the place to copy the object
+code is a network server, the Corresponding Source may be on a different server
+(operated by you or a third party) that supports equivalent copying facilities,
+provided you maintain clear directions next to the object code saying where to find
+the Corresponding Source. Regardless of what server hosts the Corresponding Source,
+you remain obligated to ensure that it is available for as long as needed to satisfy
+these requirements.
+* **e)** Convey the object code using peer-to-peer transmission, provided you inform
+other peers where the object code and Corresponding Source of the work are being
+offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the
+Corresponding Source as a System Library, need not be included in conveying the
+object code work.
+
+A &ldquo;User Product&rdquo; is either (1) a &ldquo;consumer product&rdquo;, which
+means any tangible personal property which is normally used for personal, family, or
+household purposes, or (2) anything designed or sold for incorporation into a
+dwelling. In determining whether a product is a consumer product, doubtful cases
+shall be resolved in favor of coverage. For a particular product received by a
+particular user, &ldquo;normally used&rdquo; refers to a typical or common use of
+that class of product, regardless of the status of the particular user or of the way
+in which the particular user actually uses, or expects or is expected to use, the
+product. A product is a consumer product regardless of whether the product has
+substantial commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+&ldquo;Installation Information&rdquo; for a User Product means any methods,
+procedures, authorization keys, or other information required to install and execute
+modified versions of a covered work in that User Product from a modified version of
+its Corresponding Source. The information must suffice to ensure that the continued
+functioning of the modified object code is in no case prevented or interfered with
+solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for
+use in, a User Product, and the conveying occurs as part of a transaction in which
+the right of possession and use of the User Product is transferred to the recipient
+in perpetuity or for a fixed term (regardless of how the transaction is
+characterized), the Corresponding Source conveyed under this section must be
+accompanied by the Installation Information. But this requirement does not apply if
+neither you nor any third party retains the ability to install modified object code
+on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to
+continue to provide support service, warranty, or updates for a work that has been
+modified or installed by the recipient, or for the User Product in which it has been
+modified or installed. Access to a network may be denied when the modification itself
+materially and adversely affects the operation of the network or violates the rules
+and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with
+this section must be in a format that is publicly documented (and with an
+implementation available to the public in source code form), and must require no
+special password or key for unpacking, reading or copying.
+
+### 7. Additional Terms.
+
+&ldquo;Additional permissions&rdquo; are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions. Additional
+permissions that are applicable to the entire Program shall be treated as though they
+were included in this License, to the extent that they are valid under applicable
+law. If additional permissions apply only to part of the Program, that part may be
+used separately under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any
+additional permissions from that copy, or from any part of it. (Additional
+permissions may be written to require their own removal in certain cases when you
+modify the work.) You may place additional permissions on material, added by you to a
+covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a
+covered work, you may (if authorized by the copyright holders of that material)
+supplement the terms of this License with terms:
+
+* **a)** Disclaiming warranty or limiting liability differently from the terms of
+sections 15 and 16 of this License; or
+* **b)** Requiring preservation of specified reasonable legal notices or author
+attributions in that material or in the Appropriate Legal Notices displayed by works
+containing it; or
+* **c)** Prohibiting misrepresentation of the origin of that material, or requiring that
+modified versions of such material be marked in reasonable ways as different from the
+original version; or
+* **d)** Limiting the use for publicity purposes of names of licensors or authors of the
+material; or
+* **e)** Declining to grant rights under trademark law for use of some trade names,
+trademarks, or service marks; or
+* **f)** Requiring indemnification of licensors and authors of that material by anyone
+who conveys the material (or modified versions of it) with contractual assumptions of
+liability to the recipient, for any liability that these contractual assumptions
+directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered &ldquo;further
+restrictions&rdquo; within the meaning of section 10. If the Program as you received
+it, or any part of it, contains a notice stating that it is governed by this License
+along with a term that is a further restriction, you may remove that term. If a
+license document contains a further restriction but permits relicensing or conveying
+under this License, you may add to a covered work material governed by the terms of
+that license document, provided that the further restriction does not survive such
+relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in
+the relevant source files, a statement of the additional terms that apply to those
+files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a
+separately written license, or stated as exceptions; the above requirements apply
+either way.
+
+### 8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under
+this License. Any attempt otherwise to propagate or modify it is void, and will
+automatically terminate your rights under this License (including any patent licenses
+granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a
+particular copyright holder is reinstated (a) provisionally, unless and until the
+copyright holder explicitly and finally terminates your license, and (b) permanently,
+if the copyright holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently
+if the copyright holder notifies you of the violation by some reasonable means, this
+is the first time you have received notice of violation of this License (for any
+work) from that copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of
+parties who have received copies or rights from you under this License. If your
+rights have been terminated and not permanently reinstated, you do not qualify to
+receive new licenses for the same material under section 10.
+
+### 9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the
+Program. Ancillary propagation of a covered work occurring solely as a consequence of
+using peer-to-peer transmission to receive a copy likewise does not require
+acceptance. However, nothing other than this License grants you permission to
+propagate or modify any covered work. These actions infringe copyright if you do not
+accept this License. Therefore, by modifying or propagating a covered work, you
+indicate your acceptance of this License to do so.
+
+### 10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license
+from the original licensors, to run, modify and propagate that work, subject to this
+License. You are not responsible for enforcing compliance by third parties with this
+License.
+
+An &ldquo;entity transaction&rdquo; is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an organization, or
+merging organizations. If propagation of a covered work results from an entity
+transaction, each party to that transaction who receives a copy of the work also
+receives whatever licenses to the work the party's predecessor in interest had or
+could give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if the predecessor
+has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee, royalty,
+or other charge for exercise of rights granted under this License, and you may not
+initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging
+that any patent claim is infringed by making, using, selling, offering for sale, or
+importing the Program or any portion of it.
+
+### 11. Patents.
+
+A &ldquo;contributor&rdquo; is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based. The work thus
+licensed is called the contributor's &ldquo;contributor version&rdquo;.
+
+A contributor's &ldquo;essential patent claims&rdquo; are all patent claims owned or
+controlled by the contributor, whether already acquired or hereafter acquired, that
+would be infringed by some manner, permitted by this License, of making, using, or
+selling its contributor version, but do not include claims that would be infringed
+only as a consequence of further modification of the contributor version. For
+purposes of this definition, &ldquo;control&rdquo; includes the right to grant patent
+sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license
+under the contributor's essential patent claims, to make, use, sell, offer for sale,
+import and otherwise run, modify and propagate the contents of its contributor
+version.
+
+In the following three paragraphs, a &ldquo;patent license&rdquo; is any express
+agreement or commitment, however denominated, not to enforce a patent (such as an
+express permission to practice a patent or covenant not to sue for patent
+infringement). To &ldquo;grant&rdquo; such a patent license to a party means to make
+such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the
+Corresponding Source of the work is not available for anyone to copy, free of charge
+and under the terms of this License, through a publicly available network server or
+other readily accessible means, then you must either (1) cause the Corresponding
+Source to be so available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner consistent with
+the requirements of this License, to extend the patent license to downstream
+recipients. &ldquo;Knowingly relying&rdquo; means you have actual knowledge that, but
+for the patent license, your conveying the covered work in a country, or your
+recipient's use of the covered work in a country, would infringe one or more
+identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you
+convey, or propagate by procuring conveyance of, a covered work, and grant a patent
+license to some of the parties receiving the covered work authorizing them to use,
+propagate, modify or convey a specific copy of the covered work, then the patent
+license you grant is automatically extended to all recipients of the covered work and
+works based on it.
+
+A patent license is &ldquo;discriminatory&rdquo; if it does not include within the
+scope of its coverage, prohibits the exercise of, or is conditioned on the
+non-exercise of one or more of the rights that are specifically granted under this
+License. You may not convey a covered work if you are a party to an arrangement with
+a third party that is in the business of distributing software, under which you make
+payment to the third party based on the extent of your activity of conveying the
+work, and under which the third party grants, to any of the parties who would receive
+the covered work from you, a discriminatory patent license (a) in connection with
+copies of the covered work conveyed by you (or copies made from those copies), or (b)
+primarily for and in connection with specific products or compilations that contain
+the covered work, unless you entered into that arrangement, or that patent license
+was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied
+license or other defenses to infringement that may otherwise be available to you
+under applicable patent law.
+
+### 12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise)
+that contradict the conditions of this License, they do not excuse you from the
+conditions of this License. If you cannot convey a covered work so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not convey it at all. For example, if you
+agree to terms that obligate you to collect a royalty for further conveying from
+those to whom you convey the Program, the only way you could satisfy both those terms
+and this License would be to refrain entirely from conveying the Program.
+
+### 13. Use with the GNU Affero General Public License.
+
+Notwithstanding any other provision of this License, you have permission to link or
+combine any covered work with a work licensed under version 3 of the GNU Affero
+General Public License into a single combined work, and to convey the resulting work.
+The terms of this License will continue to apply to the part which is the covered
+work, but the special requirements of the GNU Affero General Public License, section
+13, concerning interaction through a network will apply to the combination as such.
+
+### 14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU
+General Public License from time to time. Such new versions will be similar in spirit
+to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies that
+a certain numbered version of the GNU General Public License &ldquo;or any later
+version&rdquo; applies to it, you have the option of following the terms and
+conditions either of that numbered version or of any later version published by the
+Free Software Foundation. If the Program does not specify a version number of the GNU
+General Public License, you may choose any version ever published by the Free
+Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU
+General Public License can be used, that proxy's public statement of acceptance of a
+version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no
+additional obligations are imposed on any author or copyright holder as a result of
+your choosing to follow a later version.
+
+### 15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM &ldquo;AS IS&rdquo; WITHOUT WARRANTY OF ANY KIND, EITHER
+EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE
+QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE
+DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+### 16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY
+COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS
+PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL,
+INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE
+WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+### 17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be
+given local legal effect according to their terms, reviewing courts shall apply local
+law that most closely approximates an absolute waiver of all civil liability in
+connection with the Program, unless a warranty or assumption of liability accompanies
+a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+## How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to
+the public, the best way to achieve this is to make it free software which everyone
+can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them
+to the start of each source file to most effectively state the exclusion of warranty;
+and each file should have at least the &ldquo;copyright&rdquo; line and a pointer to
+where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this
+when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate parts of
+the General Public License. Of course, your program's commands might be different;
+for a GUI interface, you would use an &ldquo;about box&rdquo;.
+
+You should also get your employer (if you work as a programmer) or school, if any, to
+sign a &ldquo;copyright disclaimer&rdquo; for the program, if necessary. For more
+information on this, and how to apply and follow the GNU GPL, see
+&lt;<http://www.gnu.org/licenses/>&gt;.
+
+The GNU General Public License does not permit incorporating your program into
+proprietary programs. If your program is a subroutine library, you may consider it
+more useful to permit linking proprietary applications with the library. If this is
+what you want to do, use the GNU Lesser General Public License instead of this
+License. But first, please read
+&lt;<http://www.gnu.org/philosophy/why-not-lgpl.html>&gt;.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ You can then visit the server by going to `http://localhost:5000` in your browse
 No commits are allowed directly to master. All PRs to master need to pass status checks and be reviewed by at least one other contributor. Ideally, all pull requests should come with tests for the code within.
 
 **Branch naming** - The convention `<username>/<descriptive word or phrase>` should be used.
+
+## License
+
+This code is licensed under the GPL v3.0. For the full license text, please refer to LICENSE.md.

--- a/server/game.py
+++ b/server/game.py
@@ -11,8 +11,6 @@ SCORES = {
     'draw': '1/2-1/2'
 }
 
-SLOTS = ['OPEN', 'AI']
-
 class Game:
     """Class representing and encapsulating the logic required for handling a chess game with time controls.
 
@@ -624,9 +622,9 @@ class Game:
 
         game = cls(input_dict['creator_id'], game_id, int(input_dict['time_per_player']))
 
-        if input_dict['player1_id'] not in SLOTS:
+        if input_dict['player1_id'] != 'OPEN':
             game.add_player(input_dict['player1_id'], WHITE)
-        if input_dict['player2_id'] not in SLOTS:
+        if input_dict['player2_id'] != 'OPEN':
             game.add_player(input_dict['player2_id'], BLACK)
 
         return game

--- a/server/server.py
+++ b/server/server.py
@@ -7,7 +7,7 @@ from flask_cors import CORS
 from flask_socketio import SocketIO, join_room
 from schemas.game import MakeMoveInput, CreateGameInput, JoinGameInput, DrawOfferInput, RespondOfferInput, ResignInput
 from schemas.controller import ControllerRegisterInput, ControllerPollInput
-from .game import Game
+from .game import Game, WHITE
 from .sunfish_ai import get_ai_move
 import google.cloud
 from google.cloud import firestore
@@ -108,6 +108,13 @@ def create_game():
 
     # Create a game from the validated schema and the incremented ID.
     game = Game.from_create_game_schema(request.form, doc_ref.id)
+
+    # If the AI is the first player, make a move
+    if game.players[WHITE] == 'AI':
+        ai_san = get_ai_move(game)
+        game.move(ai_san)
+        # we're not emitting a 'move' event here because the client doesn't yet
+        # have a game ID to listen for events on
 
     # Write the game's dict to the document reference.
     # NOTE: `set` is used here rather than `create` in the event that

--- a/server/sunfish/README.md
+++ b/server/sunfish/README.md
@@ -1,0 +1,1 @@
+This code was extracted from [Sunfish](https://github.com/thomasahle/sunfish), a pure Python chess engine. It is used to generate AI moves.

--- a/server/sunfish/sunfish.py
+++ b/server/sunfish/sunfish.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env pypy
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import re, sys, time
+from itertools import count
+from collections import OrderedDict, namedtuple
+
+###############################################################################
+# Piece-Square tables. Tune these to change sunfish's behaviour
+###############################################################################
+
+piece = { 'P': 100, 'N': 280, 'B': 320, 'R': 479, 'Q': 929, 'K': 60000 }
+pst = {
+    'P': (   0,   0,   0,   0,   0,   0,   0,   0,
+            78,  83,  86,  73, 102,  82,  85,  90,
+             7,  29,  21,  44,  40,  31,  44,   7,
+           -17,  16,  -2,  15,  14,   0,  15, -13,
+           -26,   3,  10,   9,   6,   1,   0, -23,
+           -22,   9,   5, -11, -10,  -2,   3, -19,
+           -31,   8,  -7, -37, -36, -14,   3, -31,
+             0,   0,   0,   0,   0,   0,   0,   0),
+    'N': ( -66, -53, -75, -75, -10, -55, -58, -70,
+            -3,  -6, 100, -36,   4,  62,  -4, -14,
+            10,  67,   1,  74,  73,  27,  62,  -2,
+            24,  24,  45,  37,  33,  41,  25,  17,
+            -1,   5,  31,  21,  22,  35,   2,   0,
+           -18,  10,  13,  22,  18,  15,  11, -14,
+           -23, -15,   2,   0,   2,   0, -23, -20,
+           -74, -23, -26, -24, -19, -35, -22, -69),
+    'B': ( -59, -78, -82, -76, -23,-107, -37, -50,
+           -11,  20,  35, -42, -39,  31,   2, -22,
+            -9,  39, -32,  41,  52, -10,  28, -14,
+            25,  17,  20,  34,  26,  25,  15,  10,
+            13,  10,  17,  23,  17,  16,   0,   7,
+            14,  25,  24,  15,   8,  25,  20,  15,
+            19,  20,  11,   6,   7,   6,  20,  16,
+            -7,   2, -15, -12, -14, -15, -10, -10),
+    'R': (  35,  29,  33,   4,  37,  33,  56,  50,
+            55,  29,  56,  67,  55,  62,  34,  60,
+            19,  35,  28,  33,  45,  27,  25,  15,
+             0,   5,  16,  13,  18,  -4,  -9,  -6,
+           -28, -35, -16, -21, -13, -29, -46, -30,
+           -42, -28, -42, -25, -25, -35, -26, -46,
+           -53, -38, -31, -26, -29, -43, -44, -53,
+           -30, -24, -18,   5,  -2, -18, -31, -32),
+    'Q': (   6,   1,  -8,-104,  69,  24,  88,  26,
+            14,  32,  60, -10,  20,  76,  57,  24,
+            -2,  43,  32,  60,  72,  63,  43,   2,
+             1, -16,  22,  17,  25,  20, -13,  -6,
+           -14, -15,  -2,  -5,  -1, -10, -20, -22,
+           -30,  -6, -13, -11, -16, -11, -16, -27,
+           -36, -18,   0, -19, -15, -15, -21, -38,
+           -39, -30, -31, -13, -31, -36, -34, -42),
+    'K': (   4,  54,  47, -99, -99,  60,  83, -62,
+           -32,  10,  55,  56,  56,  55,  10,   3,
+           -62,  12, -57,  44, -67,  28,  37, -31,
+           -55,  50,  11,  -4, -19,  13,   0, -49,
+           -55, -43, -52, -28, -51, -47,  -8, -50,
+           -47, -42, -43, -79, -64, -32, -29, -32,
+            -4,   3, -14, -50, -57, -18,  13,   4,
+            17,  30,  -3, -14,   6,  -1,  40,  18),
+}
+# Pad tables and join piece and pst dictionaries
+for k, table in pst.items():
+    padrow = lambda row: (0,) + tuple(x+piece[k] for x in row) + (0,)
+    pst[k] = sum((padrow(table[i*8:i*8+8]) for i in range(8)), ())
+    pst[k] = (0,)*20 + pst[k] + (0,)*20
+
+###############################################################################
+# Global constants
+###############################################################################
+
+# Our board is represented as a 120 character string. The padding allows for
+# fast detection of moves that don't stay within the board.
+A1, H1, A8, H8 = 91, 98, 21, 28
+initial = (
+    '         \n'  #   0 -  9
+    '         \n'  #  10 - 19
+    ' rnbqkbnr\n'  #  20 - 29
+    ' pppppppp\n'  #  30 - 39
+    ' ........\n'  #  40 - 49
+    ' ........\n'  #  50 - 59
+    ' ........\n'  #  60 - 69
+    ' ........\n'  #  70 - 79
+    ' PPPPPPPP\n'  #  80 - 89
+    ' RNBQKBNR\n'  #  90 - 99
+    '         \n'  # 100 -109
+    '         \n'  # 110 -119
+)
+
+# Lists of possible moves for each piece type.
+N, E, S, W = -10, 1, 10, -1
+directions = {
+    'P': (N, N+N, N+W, N+E),
+    'N': (N+N+E, E+N+E, E+S+E, S+S+E, S+S+W, W+S+W, W+N+W, N+N+W),
+    'B': (N+E, S+E, S+W, N+W),
+    'R': (N, E, S, W),
+    'Q': (N, E, S, W, N+E, S+E, S+W, N+W),
+    'K': (N, E, S, W, N+E, S+E, S+W, N+W)
+}
+
+# Mate value must be greater than 8*queen + 2*(rook+knight+bishop)
+# King value is set to twice this value such that if the opponent is
+# 8 queens up, but we got the king, we still exceed MATE_VALUE.
+# When a MATE is detected, we'll set the score to MATE_UPPER - plies to get there
+# E.g. Mate in 3 will be MATE_UPPER - 6
+MATE_LOWER = piece['K'] - 10*piece['Q']
+MATE_UPPER = piece['K'] + 10*piece['Q']
+
+# The table size is the maximum number of elements in the transposition table.
+TABLE_SIZE = 1e8
+
+# Constants for tuning search
+QS_LIMIT = 150
+EVAL_ROUGHNESS = 20
+
+
+###############################################################################
+# Chess logic
+###############################################################################
+
+class Position(namedtuple('Position', 'board score wc bc ep kp')):
+    """ A state of a chess game
+    board -- a 120 char representation of the board
+    score -- the board evaluation
+    wc -- the castling rights, [west/queen side, east/king side]
+    bc -- the opponent castling rights, [west/king side, east/queen side]
+    ep - the en passant square
+    kp - the king passant square
+    """
+
+    def gen_moves(self):
+        # For each of our pieces, iterate through each possible 'ray' of moves,
+        # as defined in the 'directions' map. The rays are broken e.g. by
+        # captures or immediately in case of pieces such as knights.
+        for i, p in enumerate(self.board):
+            if not p.isupper(): continue
+            for d in directions[p]:
+                for j in count(i+d, d):
+                    q = self.board[j]
+                    # Stay inside the board, and off friendly pieces
+                    if q.isspace() or q.isupper(): break
+                    # Pawn move, double move and capture
+                    if p == 'P' and d in (N, N+N) and q != '.': break
+                    if p == 'P' and d == N+N and (i < A1+N or self.board[i+N] != '.'): break
+                    if p == 'P' and d in (N+W, N+E) and q == '.' and j not in (self.ep, self.kp): break
+                    # Move it
+                    yield (i, j)
+                    # Stop crawlers from sliding, and sliding after captures
+                    if p in 'PNK' or q.islower(): break
+                    # Castling, by sliding the rook next to the king
+                    if i == A1 and self.board[j+E] == 'K' and self.wc[0]: yield (j+E, j+W)
+                    if i == H1 and self.board[j+W] == 'K' and self.wc[1]: yield (j+W, j+E)
+
+    def rotate(self):
+        ''' Rotates the board, preserving enpassant '''
+        return Position(
+            self.board[::-1].swapcase(), -self.score, self.bc, self.wc,
+            119-self.ep if self.ep else 0,
+            119-self.kp if self.kp else 0)
+
+    def nullmove(self):
+        ''' Like rotate, but clears ep and kp '''
+        return Position(
+            self.board[::-1].swapcase(), -self.score,
+            self.bc, self.wc, 0, 0)
+
+    def move(self, move):
+        i, j = move
+        p, q = self.board[i], self.board[j]
+        put = lambda board, i, p: board[:i] + p + board[i+1:]
+        # Copy variables and reset ep and kp
+        board = self.board
+        wc, bc, ep, kp = self.wc, self.bc, 0, 0
+        score = self.score + self.value(move)
+        # Actual move
+        board = put(board, j, board[i])
+        board = put(board, i, '.')
+        # Castling rights, we move the rook or capture the opponent's
+        if i == A1: wc = (False, wc[1])
+        if i == H1: wc = (wc[0], False)
+        if j == A8: bc = (bc[0], False)
+        if j == H8: bc = (False, bc[1])
+        # Castling
+        if p == 'K':
+            wc = (False, False)
+            if abs(j-i) == 2:
+                kp = (i+j)//2
+                board = put(board, A1 if j < i else H1, '.')
+                board = put(board, kp, 'R')
+        # Pawn promotion, double move and en passant capture
+        if p == 'P':
+            if A8 <= j <= H8:
+                board = put(board, j, 'Q')
+            if j - i == 2*N:
+                ep = i + N
+            if j - i in (N+W, N+E) and q == '.':
+                board = put(board, j+S, '.')
+        # We rotate the returned position, so it's ready for the next player
+        return Position(board, score, wc, bc, ep, kp).rotate()
+
+    def value(self, move):
+        i, j = move
+        p, q = self.board[i], self.board[j]
+        # Actual move
+        score = pst[p][j] - pst[p][i]
+        # Capture
+        if q.islower():
+            score += pst[q.upper()][119-j]
+        # Castling check detection
+        if abs(j-self.kp) < 2:
+            score += pst['K'][119-j]
+        # Castling
+        if p == 'K' and abs(i-j) == 2:
+            score += pst['R'][(i+j)//2]
+            score -= pst['R'][A1 if j < i else H1]
+        # Special pawn stuff
+        if p == 'P':
+            if A8 <= j <= H8:
+                score += pst['Q'][j] - pst['P'][j]
+            if j == self.ep:
+                score += pst['P'][119-(j+S)]
+        return score
+
+###############################################################################
+# Search logic
+###############################################################################
+
+# lower <= s(pos) <= upper
+Entry = namedtuple('Entry', 'lower upper')
+
+# The normal OrderedDict doesn't update the position of a key in the list,
+# when the value is changed.
+class LRUCache:
+    '''Store items in the order the keys were last added'''
+    def __init__(self, size):
+        self.od = OrderedDict()
+        self.size = size
+
+    def get(self, key, default=None):
+        try: self.od.move_to_end(key)
+        except KeyError: return default
+        return self.od[key]
+
+    def __setitem__(self, key, value):
+        try: del self.od[key]
+        except KeyError:
+            if len(self.od) == self.size:
+                self.od.popitem(last=False)
+        self.od[key] = value
+
+class Searcher:
+    def __init__(self):
+        self.tp_score = LRUCache(TABLE_SIZE)
+        self.tp_move = LRUCache(TABLE_SIZE)
+        self.nodes = 0
+
+    def bound(self, pos, gamma, depth, root=True):
+        """ returns r where
+                s(pos) <= r < gamma    if gamma > s(pos)
+                gamma <= r <= s(pos)   if gamma <= s(pos)"""
+        self.nodes += 1
+
+        # Depth <= 0 is QSearch. Here any position is searched as deeply as is needed for calmness, and so there is no reason to keep different depths in the transposition table.
+        depth = max(depth, 0)
+
+        # Sunfish is a king-capture engine, so we should always check if we
+        # still have a king. Notice since this is the only termination check,
+        # the remaining code has to be comfortable with being mated, stalemated
+        # or able to capture the opponent king.
+        if pos.score <= -MATE_LOWER:
+            return -MATE_UPPER
+
+        # Look in the table if we have already searched this position before.
+        # We also need to be sure, that the stored search was over the same
+        # nodes as the current search.
+        entry = self.tp_score.get((pos, depth, root), Entry(-MATE_UPPER, MATE_UPPER))
+        if entry.lower >= gamma and (not root or self.tp_move.get(pos) is not None):
+            return entry.lower
+        if entry.upper < gamma:
+            return entry.upper
+
+        # Here extensions may be added
+        # Such as 'if in_check: depth += 1'
+
+        # Generator of moves to search in order.
+        # This allows us to define the moves, but only calculate them if needed.
+        def moves():
+            # First try not moving at all
+            if depth > 0 and not root and any(c in pos.board for c in 'RBNQ'):
+                yield None, -self.bound(pos.nullmove(), 1-gamma, depth-3, root=False)
+            # For QSearch we have a different kind of null-move
+            if depth == 0:
+                yield None, pos.score
+            # Then killer move. We search it twice, but the tp will fix things for us. Note, we don't have to check for legality, since we've already done it before. Also note that in QS the killer must be a capture, otherwise we will be non deterministic.
+            killer = self.tp_move.get(pos)
+            if killer and (depth > 0 or pos.value(killer) >= QS_LIMIT):
+                yield killer, -self.bound(pos.move(killer), 1-gamma, depth-1, root=False)
+            # Then all the other moves
+            for move in sorted(pos.gen_moves(), key=pos.value, reverse=True):
+                if depth > 0 or pos.value(move) >= QS_LIMIT:
+                    yield move, -self.bound(pos.move(move), 1-gamma, depth-1, root=False)
+
+        # Run through the moves, shortcutting when possible
+        best = -MATE_UPPER
+        for move, score in moves():
+            best = max(best, score)
+            if best >= gamma:
+                # Save the move for pv construction and killer heuristic
+                self.tp_move[pos] = move
+                break
+
+        # Stalemate checking is a bit tricky: Say we failed low, because
+        # we can't (legally) move and so the (real) score is -infty.
+        # At the next depth we are allowed to just return r, -infty <= r < gamma,
+        # which is normally fine.
+        # However, what if gamma = -10 and we don't have any legal moves?
+        # Then the score is actaully a draw and we should fail high!
+        # Thus, if best < gamma and best < 0 we need to double check what we are doing.
+        # This doesn't prevent sunfish from making a move that results in stalemate,
+        # but only if depth == 1, so that's probably fair enough.
+        # (Btw, at depth 1 we can also mate without realizing.)
+        if best < gamma and best < 0 and depth > 0:
+            is_dead = lambda pos: any(pos.value(m) >= MATE_LOWER for m in pos.gen_moves())
+            if all(is_dead(pos.move(m)) for m in pos.gen_moves()):
+                in_check = is_dead(pos.nullmove())
+                best = -MATE_UPPER if in_check else 0
+
+        # Table part 2
+        if best >= gamma:
+            self.tp_score[(pos, depth, root)] = Entry(best, entry.upper)
+        if best < gamma:
+            self.tp_score[(pos, depth, root)] = Entry(entry.lower, best)
+
+        return best
+
+    # secs over maxn is a breaking change. Can we do this?
+    # I guess I could send a pull request to deep pink
+    # Why include secs at all?
+    def _search(self, pos):
+        """ Iterative deepening MTD-bi search """
+        self.nodes = 0
+
+        # In finished games, we could potentially go far enough to cause a recursion
+        # limit exception. Hence we bound the ply.
+        for depth in range(1, 1000):
+            self.depth = depth
+            # The inner loop is a binary search on the score of the position.
+            # Inv: lower <= score <= upper
+            # 'while lower != upper' would work, but play tests show a margin of 20 plays better.
+            lower, upper = -MATE_UPPER, MATE_UPPER
+            while lower < upper - EVAL_ROUGHNESS:
+                gamma = (lower+upper+1)//2
+                score = self.bound(pos, gamma, depth)
+                if score >= gamma:
+                    lower = score
+                if score < gamma:
+                    upper = score
+            # We want to make sure the move to play hasn't been kicked out of the table,
+            # So we make another call that must always fail high and thus produce a move.
+            score = self.bound(pos, lower, depth)
+
+            # Yield so the user may inspect the search
+            yield
+
+    def search(self, pos, secs):
+        start = time.time()
+        for _ in self._search(pos):
+            if time.time() - start > secs:
+                break
+        # If the game hasn't finished we can retrieve our move from the
+        # transposition table.
+        return self.tp_move.get(pos), self.tp_score.get((pos, self.depth, True)).lower
+
+
+###############################################################################
+# User interface
+###############################################################################
+
+# Python 2 compatability
+if sys.version_info[0] == 2:
+    input = raw_input
+    class NewOrderedDict(OrderedDict):
+        def move_to_end(self, key):
+            value = self.pop(key)
+            self[key] = value
+    OrderedDict = NewOrderedDict
+
+
+def parse(c):
+    fil, rank = ord(c[0]) - ord('a'), int(c[1]) - 1
+    return A1 + fil - 10*rank
+
+
+def render(i):
+    rank, fil = divmod(i - A1, 10)
+    return chr(fil + ord('a')) + str(-rank + 1)
+
+
+def print_pos(pos):
+    print()
+    uni_pieces = {'R':'♜', 'N':'♞', 'B':'♝', 'Q':'♛', 'K':'♚', 'P':'♟',
+                  'r':'♖', 'n':'♘', 'b':'♗', 'q':'♕', 'k':'♔', 'p':'♙', '.':'·'}
+    for i, row in enumerate(pos.board.split()):
+        print(' ', 8-i, ' '.join(uni_pieces.get(p, p) for p in row))
+    print('    a b c d e f g h \n\n')
+
+
+def main():
+    pos = Position(initial, 0, (True,True), (True,True), 0, 0)
+    searcher = Searcher()
+    while True:
+        print_pos(pos)
+
+        if pos.score <= -MATE_LOWER:
+            print("You lost")
+            break
+
+        # We query the user until she enters a (pseudo) legal move.
+        move = None
+        while move not in pos.gen_moves():
+            match = re.match('([a-h][1-8])'*2, input('Your move: '))
+            if match:
+                move = parse(match.group(1)), parse(match.group(2))
+            else:
+                # Inform the user when invalid input (e.g. "help") is entered
+                print("Please enter a move like g8f6")
+        pos = pos.move(move)
+
+        # After our move we rotate the board and print it again.
+        # This allows us to see the effect of our move.
+        print_pos(pos.rotate())
+
+        if pos.score <= -MATE_LOWER:
+            print("You won")
+            break
+
+        # Fire up the engine to look for a move.
+        move, score = searcher.search(pos, secs=2)
+
+        if score == MATE_UPPER:
+            print("Checkmate!")
+
+        # The black player moves from a rotated position, so we have to
+        # 'back rotate' the move before printing it.
+        print("My move:", render(119-move[0]) + render(119-move[1]))
+        pos = pos.move(move)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/server/sunfish/tools.py
+++ b/server/sunfish/tools.py
@@ -1,0 +1,213 @@
+import itertools
+import re
+
+import sunfish.sunfish as sunfish
+
+################################################################################
+# This module contains functions used by test.py and xboard.py.
+# Nothing from here is imported into sunfish.py which is entirely self-sufficient
+################################################################################
+
+# Sunfish doesn't have to know about colors, but for more advanced things, such
+# as xboard support, we have to.
+WHITE, BLACK = range(2)
+
+FEN_INITIAL = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+
+################################################################################
+# Parse and Render moves
+################################################################################
+
+def gen_legal_moves(pos):
+    ''' pos.gen_moves(), but without those that leaves us in check.
+        Also the position after moving is included. '''
+    for move in pos.gen_moves():
+        pos1 = pos.move(move)
+        # If we just checked for opponent moves capturing the king, we would miss
+        # captures in case of illegal castling.
+        if not any(pos1.value(m) >= sunfish.MATE_LOWER for m in pos1.gen_moves()):
+            yield move, pos1
+
+def mrender(pos, m):
+    # Sunfish always assumes promotion to queen
+    p = 'q' if sunfish.A8 <= m[1] <= sunfish.H8 and pos.board[m[0]] == 'P' else ''
+    m = m if get_color(pos) == WHITE else (119-m[0], 119-m[1])
+    return sunfish.render(m[0]) + sunfish.render(m[1]) + p
+
+def mparse(color, move):
+    m = (sunfish.parse(move[0:2]), sunfish.parse(move[2:4]))
+    return m if color == WHITE else (119-m[0], 119-m[1])
+
+def renderSAN(pos, move):
+    ''' Assumes board is rotated to position of current player '''
+    i, j = move
+    csrc, cdst = sunfish.render(i), sunfish.render(j)
+    # Rotate flor black
+    if get_color(pos) == BLACK:
+        csrc, cdst = sunfish.render(119-i), sunfish.render(119-j)
+    # Check
+    pos1 = pos.move(move)
+    cankill = lambda p: any(p.board[b]=='k' for a,b in p.gen_moves())
+    check = ''
+    if cankill(pos1.rotate()):
+        check = '+'
+        if all(cankill(pos1.move(move1)) for move1 in pos1.gen_moves()):
+            check = '#'
+    # Castling
+    if pos.board[i] == 'K' and abs(i-j) == 2:
+        if get_color(pos) == WHITE and j > i or get_color(pos) == BLACK and j < i:
+            return 'O-O' + check
+        else:
+            return 'O-O-O' + check
+    # Pawn moves
+    if pos.board[i] == 'P':
+        pro = '=Q' if sunfish.A8 <= j <= sunfish.H8 else ''
+        cap = csrc[0] + 'x' if pos.board[j] != '.' or j == pos.ep else ''
+        return cap + cdst + pro + check
+    # Figure out what files and ranks we need to include
+    srcs = [a for (a,b),_ in gen_legal_moves(pos) if pos.board[a] == pos.board[i] and b == j]
+    srcs_file = [a for a in srcs if (a - sunfish.A1) % 10 == (i - sunfish.A1) % 10]
+    srcs_rank = [a for a in srcs if (a - sunfish.A1) // 10 == (i - sunfish.A1) // 10]
+    assert srcs, 'No moves compatible with {}'.format(move)
+    if len(srcs) == 1: src = ''
+    elif len(srcs_file) == 1: src = csrc[0]
+    elif len(srcs_rank) == 1: src = csrc[1]
+    else: src = csrc
+    # Normal moves
+    p = pos.board[i]
+    cap = 'x' if pos.board[j] != '.' else ''
+    return p + src + cap + cdst + check
+
+def parseSAN(pos, msan):
+    ''' Assumes board is rotated to position of current player '''
+    # Normal moves
+    normal = re.match('([KQRBN])([a-h])?([1-8])?x?([a-h][1-8])', msan)
+    if normal:
+        p, fil, rank, dst = normal.groups()
+        src = (fil or '[a-h]')+(rank or '[1-8]')
+    # Pawn moves
+    pawn = re.match('([a-h])?x?([a-h][1-8])', msan)
+    if pawn:
+        p, (fil, dst) = 'P', pawn.groups()
+        src = (fil or '[a-h]')+'[1-8]'
+    # Castling
+    if re.match(msan, "O-O-O[+#]?"):
+        p, src, dst = 'K', 'e[18]', 'c[18]'
+    if re.match(msan, "O-O[+#]?"):
+        p, src, dst = 'K', 'e[18]', 'g[18]'
+    # Find possible match
+    for (i, j), _ in gen_legal_moves(pos):
+        if get_color(pos) == WHITE:
+            csrc, cdst = sunfish.render(i), sunfish.render(j)
+        else: csrc, cdst = sunfish.render(119-i), sunfish.render(119-j)
+        if pos.board[i] == p and re.match(dst,cdst) and re.match(src,csrc):
+            return (i, j)
+    assert False
+
+################################################################################
+# Parse and Render positions
+################################################################################
+
+def get_color(pos):
+    ''' A slightly hacky way to to get the color from a sunfish position '''
+    return BLACK if pos.board.startswith('\n') else WHITE
+
+def parseFEN(fen):
+    """ Parses a string in Forsyth-Edwards Notation into a Position """
+    board, color, castling, enpas, _hclock, _fclock = fen.split()
+    board = re.sub(r'\d', (lambda m: '.'*int(m.group(0))), board)
+    board = list(21*' ' + '  '.join(board.split('/')) + 21*' ')
+    board[9::10] = ['\n']*12
+    #if color == 'w': board[::10] = ['\n']*12
+    #if color == 'b': board[9::10] = ['\n']*12
+    board = ''.join(board)
+    wc = ('Q' in castling, 'K' in castling)
+    bc = ('k' in castling, 'q' in castling)
+    ep = sunfish.parse(enpas) if enpas != '-' else 0
+    score = sum(sunfish.pst[p][i] for i,p in enumerate(board) if p.isupper())
+    score -= sum(sunfish.pst[p.upper()][119-i] for i,p in enumerate(board) if p.islower())
+    pos = sunfish.Position(board, score, wc, bc, ep, 0)
+    return pos if color == 'w' else pos.rotate()
+
+def renderFEN(pos, half_move_clock=0, full_move_clock=1):
+    color = 'wb'[get_color(pos)]
+    if get_color(pos) == BLACK:
+        pos = pos.rotate()
+    board = '/'.join(pos.board.split())
+    board = re.sub(r'\.+', (lambda m: str(len(m.group(0)))), board)
+    castling = ''.join(itertools.compress('KQkq', pos.wc[::-1]+pos.bc)) or '-'
+    ep = sunfish.render(pos.ep) if not pos.board[pos.ep].isspace() else '-'
+    clock = '{} {}'.format(half_move_clock, full_move_clock)
+    return ' '.join((board, color, castling, ep, clock))
+
+def parseEPD(epd, opt_dict=False):
+    epd = epd.strip('\n ;').replace('"','')
+    parts = epd.split(maxsplit=6)
+    opt_part = ''
+    if len(parts) >= 6 and parts[4].isdigit() and parts[5].isdigit():
+        fen = ' '.join(parts[:6])
+        opt_part = ' '.join(parts[6:])
+    else:
+        # Sometimes fen doesn't include half move clocks
+        fen = ' '.join(parts[:4]) + ' 0 1'
+        opt_part = ' '.join(parts[4:])
+    # EPD operations may either be <opcode> or (<opcode> <operand>)
+    opts = opt_part.split(';')
+    if opt_dict:
+        opts = dict(p.split(maxsplit=1) for p in opts)
+    return fen, opts
+
+################################################################################
+# Pretty print
+################################################################################
+
+def pv(searcher, pos, include_scores=True):
+    res = []
+    seen_pos = set()
+    color = get_color(pos)
+    origc = color
+    if include_scores:
+        res.append(str(pos.score))
+    while True:
+        move = searcher.tp_move.get(pos)
+        if move is None:
+            break
+        res.append(mrender(pos, move))
+        pos, color = pos.move(move), 1-color
+        if pos in seen_pos:
+            res.append('loop')
+            break
+        seen_pos.add(pos)
+        if include_scores:
+            res.append(str(pos.score if color==origc else -pos.score))
+    return ' '.join(res)
+
+################################################################################
+# Bulk move generation
+################################################################################
+
+def expand_position(pos):
+    ''' Yields a tree of generators [p, [p, [...], ...], ...] rooted at pos '''
+    yield pos
+    for _, pos1 in gen_legal_moves(pos):
+        yield expand_position(pos1)
+
+def collect_tree_depth(tree, depth):
+    ''' Yields positions exactly at depth '''
+    root = next(tree)
+    if depth == 0:
+        yield root
+    else:
+        for subtree in tree:
+            for pos in collect_tree_depth(subtree, depth-1):
+                yield pos
+
+def flatten_tree(tree, depth):
+    ''' Yields positions exactly at less than depth '''
+    if depth == 0:
+        return
+    yield next(tree)
+    for subtree in tree:
+        for pos in flatten_tree(subtree, depth-1):
+            yield pos
+

--- a/server/sunfish_ai.py
+++ b/server/sunfish_ai.py
@@ -1,0 +1,15 @@
+"""Interface to the Sunfish chess engine."""
+from sunfish.tools import parseFEN, renderSAN
+from sunfish.sunfish import Searcher
+
+def get_ai_move(board):
+    """Given a python-chess Board, produce a move.
+
+    This is the main entry point to using Sunfish as an AI.
+    @return A move in SAN
+    """
+    fen = board.fen()
+    position = parseFEN(fen)
+    searcher = Searcher()
+    move, _ = searcher.search(position, secs=2)
+    return renderSAN(position, move)

--- a/server/sunfish_ai.py
+++ b/server/sunfish_ai.py
@@ -2,13 +2,13 @@
 from sunfish.tools import parseFEN, renderSAN
 from sunfish.sunfish import Searcher
 
-def get_ai_move(board):
-    """Given a python-chess Board, produce a move.
+def get_ai_move(game):
+    """Given a Game object, produce a move.
 
     This is the main entry point to using Sunfish as an AI.
     @return A move in SAN
     """
-    fen = board.fen()
+    fen = game.fen
     position = parseFEN(fen)
     searcher = Searcher()
     move, _ = searcher.search(position, secs=2)


### PR DESCRIPTION
See #44 

# Description
This PR incorporates a chess engine called [Sunfish](https://github.com/thomasahle/sunfish) as an AI to play chess against. A lot of the framework was there which means this won't be a breaking change, but there are some large changes to the server as a whole, as documented below.

# Changes
 - **Big change** This requires the license of the repo to become GPL since Sunfish uses GPL and the GPL works like that. See a guide [here](https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)).
 - Copy code from the Sunfish repo into this project. All code inside `server/sunfish/` is Sunfish code.
 - Adds an interface that exposes a `get_ai_move(Game game)` function to make it easier to replace Sunfish if we need to.
 - Changes `/makemove` to make an AI move after the human player moves.
 - Changes `/creategame` to make an AI move if the AI is playing white (since otherwise the game would never start since we model the AI as reactive).
 - Fixes a bug in `Game.from_create_game_schema` where the AI player would be set to `None`.

# What this doesn't do
 - This doesn't allow for configurable levels. The AI is one difficulty and that's it.
 - Go fast. The Sunfish AI using normal Python is kinda slow. It can take a few seconds to make a move and I've never made a move with it past turn 2.
 - Take into account clocks. This PR doesn't know about how we're going to do time.

**Important** - We should put a vote to the group just to make sure that everyone is happy with making this code GPL before merging this.