### PR TITLE
Change controller timeout to 10 minutes

### DIFF
--- a/server/schemas/controller.py
+++ b/server/schemas/controller.py
@@ -3,7 +3,7 @@ from marshmallow import Schema, fields, validates, validates_schema, ValidationE
 
 GAMES_COLLECTION = "games"
 CONTROLLER_COLLECTION = "controllers"
-TIMEOUT = 60 # seconds
+TIMEOUT = 600 # 10 minutes
 
 class ControllerRegisterInput(Schema):
     board_id        = fields.String(required=True)


### PR DESCRIPTION
See #50 

Simple PR that changes the controller timeout from 1 minute to 10. This should avoid any problems with the controller taking too long to make a move and having to re-register with the server. The controller timeout should be set to a value beyond which it is likely the controller has crashed but above the longest likely time for the controller to make moves.