### PR TITLE
Add initial_positions to controllerpoll response

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -186,7 +186,8 @@ def controller_poll():
     controller_dict['last_ply_count'] = ply_count
     controller_ref.set(controller_dict)
 
-    poll_response = {'game_over': {'game_over': False, 'reason': None}, 'history': []}
+    poll_response = {'game_over': {'game_over': False, 'reason': None},
+                     'history': [], 'initial_positions': {}}
 
     if error != -1:
         # let web app know about error
@@ -195,6 +196,7 @@ def controller_poll():
     if game_id is not None and error == -1:
         game_dict = db.collection(GAMES_COLLECTION).document(game_id).get().to_dict()
         poll_response['game_over'] = game_dict['game_over']
+        poll_response['initial_positions'] = game_dict['initial_positions']
 
         # game_dict['ply_count'] == len(history)
         for i in range(ply_count, game_dict['ply_count']):

--- a/test/routes/test_controller_poll.py
+++ b/test/routes/test_controller_poll.py
@@ -29,7 +29,8 @@ NO_HISTORY = {"creator": "some_creator",
               "draw_offers": {
                   "w": {"made": False, "accepted": False},
                   "b": {"made": False, "accepted": False}
-              }
+              },
+              "initial_positions": {}
              }
 
 TWO_MOVES = {"creator": "some_creator",
@@ -55,7 +56,8 @@ TWO_MOVES = {"creator": "some_creator",
              "draw_offers": {
                  "w": {"made": False, "accepted": False},
                  "b": {"made": False, "accepted": False}
-             }
+             },
+             "initial_positions": {}
             }
 
 @patch('server.server.db', new_callable=MockClient)


### PR DESCRIPTION
When the controller finishes a game, it needs to be able to reset itself to its starting state. The controller does not keep track of what pieces are where and so needs some state to reset itself based on. This PR sends it the `initial_positions` dictionary that's kept in the game object in the response to `/controllerpoll`. This means that the controller can check the `game_over` field to find out if it needs to reset, and if it does then it can use the `initial_positions` dictionary to reset itself since the dictionary keeps track of the initial position of every piece on the board.

For context on the object, see #40 