### PR TITLE
Assign controller in /creategame

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -123,6 +123,13 @@ def create_game():
     #   game is stored with ID 0, instead of raising an error.
     doc_ref.set(game.to_dict())
 
+    # Assign controller to this game
+    controller_id = request.form['board_id']
+    controller_ref = db.collection(CONTROLLER_COLLECTION).document(controller_id)
+    controller_dict = controller_ref.get().to_dict()
+    controller_dict['game_id'] = doc_ref.id
+    controller_ref.set(controller_dict)
+
     # Update the incremented ID count on the `/counts/games` document.
     # HACK: Firebase's `update` does not seem to work for this purpose,
     #   otherwise we could do `count_ref.update({'count': int(count)})`.


### PR DESCRIPTION
See #56 

This PR assigns the requested controller on a call to `/creategame`. It includes checks for the controller existing and being active recently. It also adds tests for this behaviour.

**Note** - One thing this doesn't do is to check if the controller already has a game assigned. This means that `/creategame` will overwrite any previous assignments to that controller. This is intended since it's the smoothest behaviour for the demo. This should be fixed later by adding in permissions for controllers so only an owner could overwrite etc. 